### PR TITLE
Plugin right click tray

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "src/plugins/gif-creator"]
 	path = src/plugins/video-creator
 	url = https://github.com/jared-hughes/desmodder-video-creator.git
+[submodule "src/plugins/right-click-tray"]
+	path = src/plugins/right-click-tray
+	url = https://github.com/SlimRunner/right-click-tray.git

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -2,6 +2,7 @@ import duplicateHotkey from "plugins/duplicateHotkey";
 import findReplace from "plugins/find-replace/index";
 import wolfram2desmos from "plugins/wolfram2desmos";
 import videoCreator from "plugins/video-creator/index";
+import rightClickTray from "plugins/right-click-tray/index";
 
 export interface Plugin {
   name: string;
@@ -30,4 +31,5 @@ export default [
   duplicateHotkey,
   findReplace,
   wolfram2desmos,
+	rightClickTray,
 ] as ReadonlyArray<Plugin>;


### PR DESCRIPTION
The syntax of the plugin is a bit messy because my inexperience with typescript, but it works exactly as it should when disabled and enabled.

You might want to review the order of the toggles. I put it at the bottom.

In short what the plugin does is enable the user to right click the expression's settings bubble instead of having to long hold.