### PR TITLE
🐛 Enable cross-origin resource protection

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -19,8 +19,17 @@
       "matches": ["https://www.desmos.com/*"]
     }
   ],
-  "permissions": ["storage"],
-  "host_permissions": ["https://www.desmos.com/*"],
+  "declarative_net_request": {
+    "rule_resources": [
+      {
+        "id": "ruleset_1",
+        "enabled": true,
+        "path": "net_request_rules.json"
+      }
+    ]
+  },
+  "permissions": ["storage", "declarativeNetRequest"],
+  "host_permissions": ["https://*.desmos.com/*"],
   "externally_connectable": {
     "matches": ["https://www.desmos.com/*"]
   }

--- a/public/net_request_rules.json
+++ b/public/net_request_rules.json
@@ -1,0 +1,43 @@
+[
+  {
+    "id": 1,
+    "priority": 1,
+    "action": {
+      "type": "modifyHeaders",
+      "responseHeaders": [
+        {
+          "header": "Cross-Origin-Embedder-Policy",
+          "operation": "set",
+          "value": "require-corp"
+        },
+        {
+          "header": "Cross-Origin-Opener-Policy",
+          "operation": "set",
+          "value": "same-origin"
+        }
+      ]
+    },
+    "condition": {
+      "urlFilter": "https://*.desmos.com/*",
+      "resourceTypes": ["main_frame", "script"]
+    }
+  },
+  {
+    "id": 2,
+    "priority": 1,
+    "action": {
+      "type": "modifyHeaders",
+      "responseHeaders": [
+        {
+          "header": "Cross-Origin-Resource-Policy",
+          "operation": "set",
+          "value": "cross-origin"
+        }
+      ]
+    },
+    "condition": {
+      "urlFilter": "https://*.desmos.com/*",
+      "resourceTypes": ["image"]
+    }
+  }
+]

--- a/public/net_request_rules.md
+++ b/public/net_request_rules.md
@@ -1,0 +1,9 @@
+Overview of header modification:
+
+The manifest specifies that `https://*.desmos.com/*` can be modified, and it loads the ruleset `net_request_rules.json` through the [declarativeNetRequest](https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest) API.
+
+The ruleset `net_request_rules.json` modifies the headers on Desmos URLs to include:
+
+- `Cross-Origin-Embedder-Policy: require-corp` and `Cross-Origin-Opener-Policy: same-origin` to [enable SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer), necessary for ffmpeg.wasm for video-creator export
+  - Only the resource types `main_frame` and `script` are included here as a minimal set. If more are needed, see the [full list of resource types](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/ResourceType)
+- `Cross-Origin-Resource-Policy: cross-origin` is necessary to permit loading thumbnail images through `saved-work.desmos.com` from `www.desmos.com`


### PR DESCRIPTION
This avoids the warning "SharedArrayBuffer will require cross-origin 
isolation as of M91, around May 2021."

Resolves 
https://github.com/jared-hughes/desmodder-video-creator/issues/3